### PR TITLE
Remove base_url from plotly function because its deprecated

### DIFF
--- a/Examples/Diamonds/global.R
+++ b/Examples/Diamonds/global.R
@@ -3,6 +3,6 @@
 library(plotly)
 library(shiny)
 
-py <- plotly(username="rAPI", key="yu680v5eii", base_url="https://plot.ly")
+py <- plotly(username="rAPI", key="yu680v5eii")
 
 source("plotlyGraphWidget.R")

--- a/Examples/Movies/global.R
+++ b/Examples/Movies/global.R
@@ -3,6 +3,6 @@
 library(plotly)
 library(shiny)
 
-py <- plotly(username="rAPI", key="yu680v5eii", base_url="https://plot.ly")
+py <- plotly(username="rAPI", key="yu680v5eii")
 
 source("plotlyGraphWidget.R")

--- a/Examples/UN_Advanced/global.R
+++ b/Examples/UN_Advanced/global.R
@@ -4,7 +4,7 @@ library(plotly)
 library(shiny)
 library(dplyr)
 
-py <- plotly(username="rAPI", key="yu680v5eii", base_url="https://plot.ly")
+py <- plotly(username="rAPI", key="yu680v5eii")
 
 source("plotlyGraphWidget.R")
 

--- a/Examples/UN_Simple/global.R
+++ b/Examples/UN_Simple/global.R
@@ -4,7 +4,7 @@ library(plotly)
 library(shiny)
 library(dplyr)
 
-py <- plotly(username="rAPI", key="yu680v5eii", base_url="https://plot.ly")
+py <- plotly(username="rAPI", key="yu680v5eii")
 
 source("plotlyGraphWidget.R")
 

--- a/What_You_Need/global.R
+++ b/What_You_Need/global.R
@@ -3,6 +3,6 @@
 library(plotly)
 library(shiny)
 
-py <- plotly(username="rAPI", key="yu680v5eii", base_url="https://plot.ly")
+py <- plotly(username="rAPI", key="yu680v5eii")
 
 source("plotlyGraphWidget.R")


### PR DESCRIPTION
Not sure which fork I'm supposed to send the PR to. Apologies if I sent it to the wrong one.